### PR TITLE
Workaround for where route get default fail

### DIFF
--- a/lib/facter/main_interface.rb
+++ b/lib/facter/main_interface.rb
@@ -21,6 +21,11 @@ Facter.add('main_interface') do
   setcode do
     begin
       main_interface = `route get default | awk '/interface/ { print $2 }'`.strip
+
+      if main_interface.empty?
+        main_interface = `netstat -rn | awk '/^default/ { print $6 }' | head -1`.strip
+      end
+
       main_interface = main_interface.gsub(/[^a-z0-9_]/i, '_')
 
       if Facter.value(:is_virtual).strip == 'true'


### PR DESCRIPTION
On some systems, route get default fail to find the default gw and responds with "default: not in table".
Not sure exactly why but a theory is that it's related to shared-ip zones on a Solaris 10 gz containing multiple default routes on different networks.
This ugly hack is obviously not failsafe, e.g. if there are multiple default gw's. However, that should not appear inside a shared-ip zone and on other systems, route get default is expected to work (if the theory above is correct.)
The change has been tested on +90% of the Solaris hosts in the KI-hub.
